### PR TITLE
Specify angularVelocity and linearVelocity on rigidBody when putdown

### DIFF
--- a/main.js
+++ b/main.js
@@ -103,8 +103,18 @@ AFRAME.registerComponent("toggle-physics", {
     pickup: function() {
       this.el.addState('grabbed');
     },
-    putdown: function() {
+    putdown: function(e) {
       this.el.removeState('grabbed');
+      if (e.detail.frame && e.detail.inputSource) {
+        const referenceSpace = this.el.sceneEl.renderer.xr.getReferenceSpace();
+        const pose = e.detail.frame.getPose(e.detail.inputSource.gripSpace, referenceSpace);
+        if (pose && pose.angularVelocity) {
+          this.el.components['physx-body'].rigidBody.setAngularVelocity(pose.angularVelocity);
+        }
+        if (pose && pose.linearVelocity) {
+          this.el.components['physx-body'].rigidBody.setLinearVelocity(pose.linearVelocity);
+        }
+      }
     }
   }
 });


### PR DESCRIPTION
I put back setting angularVelocity and linearVelocity that you did initially with ammo, but was commented when you switched to physx.
I tested launching the pot like a frisbee, this works far better with this code.
Note that pose.angularVelocity and pose.linearVelocity are of type https://developer.mozilla.org/en-US/docs/Web/API/DOMPointReadOnly but it seems to work without issue.
