### PR TITLE
Allow to specify the Texture channel for the lightmap

### DIFF
--- a/model-utils.js
+++ b/model-utils.js
@@ -13,6 +13,10 @@ AFRAME.registerComponent('lightmap', {
     },
     basis: {
       default: false
+    },
+    channel: {
+      type: 'int',
+      default: 1
     }
   },
   init() {
@@ -20,6 +24,7 @@ AFRAME.registerComponent('lightmap', {
     const src = typeof this.data.src === 'string' ? this.data.src : this.data.src.src;
     const texture = new THREE.TextureLoader().load(src);
     texture.flipY = false;
+    texture.channel = this.data.channel;
     this.texture = texture;
 
     this.el.addEventListener('object3dset', this.update.bind(this));


### PR DESCRIPTION
Dear maintainers,

newer three.js versions support multiple uv attributes for gltf models. This introduces the need to specify which uv attribute is the one relevant for our lightmap texture.

See e.g. https://github.com/mrdoob/three.js/pull/25721

Without this change, we experience a regression when loading this scene between A-Frame 1.4.2 and 1.5.0 (see picture)

![Schermata del 2024-01-12 14-03-27](https://github.com/AdaRoseCannon/aframe-xr-boilerplate/assets/3331940/8d8654bf-9691-4c50-b02b-7945fe47fc75)

This code seems to work fine on 1.4.2 and 1.5.0

All the best