### PR TITLE
Refactor to prevent array allocations whenever we update the entities

### DIFF
--- a/simple-navmesh-constraint.js
+++ b/simple-navmesh-constraint.js
@@ -27,6 +27,9 @@ AFRAME.registerComponent('simple-navmesh-constraint', {
 
     this.el.sceneEl.addEventListener('child-attached', this.onSceneUpdated);
     this.el.sceneEl.addEventListener('child-detached', this.onSceneUpdated);
+
+    this.objects = [];
+    this.excludes = [];
   },
 
   remove: function () {
@@ -45,13 +48,22 @@ AFRAME.registerComponent('simple-navmesh-constraint', {
   },
 
   updateNavmeshEntities: function () {
-    this.excludes = this.data.exclude ? Array.from(document.querySelectorAll(this.data.exclude)):[];
-    const els = Array.from(document.querySelectorAll(this.data.navmesh));
-    if (els === null) {
+    this.objects.length = 0;
+    this.excludes.length = 0;
+
+    if (this.data.navmesh.length > 0) {
+      for (const navmesh of document.querySelectorAll(this.data.navmesh)) {
+	this.objects.push(navmesh.object3D);
+      }
+    }
+
+    if (this.objects.length === 0) {
       console.warn('simple-navmesh-constraint: Did not match any elements');
-      this.objects = [];
-    } else {
-      this.objects = els.map(el => el.object3D).concat(this.excludes.map(el => el.object3D));
+    } else if (this.data.exclude.length > 0) {
+      for (const excluded of document.querySelectorAll(this.data.exclude)) {
+        this.objects.push(excluded.object3D);
+        this.excludes.push(excluded);
+      }
     }
 
     this.entitiesChanged = false;


### PR DESCRIPTION
As mentioned in #27, it would be nice if updating the entities did not require additional array allocations all the time.

This is my attempt at it.

All the best