### PR TITLE
setAngularVelocity and setLinearVelocity need a second autowake parameter

### DIFF
--- a/main.js
+++ b/main.js
@@ -109,10 +109,10 @@ AFRAME.registerComponent("toggle-physics", {
         const referenceSpace = this.el.sceneEl.renderer.xr.getReferenceSpace();
         const pose = e.detail.frame.getPose(e.detail.inputSource.gripSpace, referenceSpace);
         if (pose && pose.angularVelocity) {
-          this.el.components['physx-body'].rigidBody.setAngularVelocity(pose.angularVelocity);
+          this.el.components['physx-body'].rigidBody.setAngularVelocity(pose.angularVelocity, true);
         }
         if (pose && pose.linearVelocity) {
-          this.el.components['physx-body'].rigidBody.setLinearVelocity(pose.linearVelocity);
+          this.el.components['physx-body'].rigidBody.setLinearVelocity(pose.linearVelocity, true);
         }
       }
     }


### PR DESCRIPTION
I got an error in my project saying those functions require 2 params.
https://gameworksdocs.nvidia.com/PhysX/4.0/documentation/PhysXAPI/files/classPxRigidBody.html#ad49850630db14af26e019d2550ecfd27