### PR TITLE
physx-body-from-model: support setting a second time the component

### DIFF
--- a/main.js
+++ b/main.js
@@ -86,11 +86,10 @@ AFRAME.registerComponent("physx-body-from-model", {
     default: ''
   },
   init () {
-    const details = this.data;
-    this.onLoad = function () {
-      this.setAttribute('physx-body', details);
-      this.removeAttribute('physx-body-from-model');
-    }
+    this.onLoad = () => {
+      this.el.setAttribute("physx-body", this.data);
+      this.el.removeAttribute("physx-body-from-model");
+    };
     this.el.addEventListener('object3dset', this.onLoad);
   },
   remove () {


### PR DESCRIPTION
For the `physx-body-from-model` component, add support to set a second time the component with different props in the same tick.

Example using in some generic function:
```js
boxEl.setAttribute("physx-body-from-model", "type: dynamic");
```
and later but in the same tick you want that specific box to have a different mass
```js
boxEl.setAttribute("physx-body-from-model", "type: dynamic; mass: 2");
```