### PR TITLE
Use aframe master to fix AR mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,9 @@
   </script>
 
   <!-- the AFrame library and 3rd party components -->
-  <script src="https://cdn.jsdelivr.net/npm/aframe@1.7.0/dist/aframe-master.min.js"></script>
+  <!-- use master for now, waiting for 1.7.1 release that fixes an issue with ar-hit-test component https://github.com/aframevr/aframe/pull/5680 -->
+  <script src="https://cdn.jsdelivr.net/gh/aframevr/aframe@cd543c6cbf52c81f14ac0d3a41cb9a883047c7ac/dist/aframe-master.min.js"></script>
+  <!--<script src="https://cdn.jsdelivr.net/npm/aframe@1.7.0/dist/aframe-master.min.js"></script>-->
   <script src="https://cdn.jsdelivr.net/npm/aframe-environment-component@1.5.0/dist/aframe-environment-component.min.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.4/dist/components/sphere-collider.min.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.4/dist/aframe-extras.controls.min.js"></script>


### PR DESCRIPTION
Use master for now, waiting for 1.7.1 release that fixes an issue with ar-hit-test component https://github.com/aframevr/aframe/pull/5680